### PR TITLE
urls that end in slash should be network first

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -92,7 +92,34 @@ module.exports = {
         icon: `content/assets/favicon.ico`,
       },
     },
-    `gatsby-plugin-offline`,
+    {
+      resolve: `gatsby-plugin-offline`,
+      options: {
+        runtimeCaching: [
+          {
+            // Use cacheFirst since these don't need to be revalidated (same RegExp
+            // and same reason as above)
+            urlPattern: /(\.js$|\.css$|static\/)/,
+            handler: `cacheFirst`,
+          },
+          {
+            // Add runtime caching of various other page resources
+            urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
+            handler: `staleWhileRevalidate`,
+          },
+          {
+            // Google Fonts CSS (doesn't end in .css so we need to specify it)
+            urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
+            handler: `staleWhileRevalidate`,
+          },
+          {
+            // don't use cache for trailing slash urls, or urls that end in .dev
+            urlPattern: /(\/|\.dev)$/,
+            handler: "networkFirst"
+          }
+        ],
+    }
+  },
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-plugin-typography`,


### PR DESCRIPTION
* urls that end in slash should be cached as network first, not cache first (so the homepage and tag pages should not be served from cache first)